### PR TITLE
remove bracket-colorizer -- now a native feature, plugin is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
         "atlassian.atlascode",
         "christian-kohler.npm-intellisense",
         "christian-kohler.path-intellisense",
-        "CoenraadS.bracket-pair-colorizer",
         "dbaeumer.vscode-eslint",
         "eamodio.gitlens",
         "EditorConfig.EditorConfig",


### PR DESCRIPTION
Bracket Colorizer kept nagging me that it was no longer maintained.

I checked and found that it's been discontinued because VS Code no has the feature natively.